### PR TITLE
CSS fixes required by OpenStack Juno

### DIFF
--- a/contrail_openstack_dashboard/openstack_dashboard/dashboards/project/networking/templates/networking/index.html
+++ b/contrail_openstack_dashboard/openstack_dashboard/dashboards/project/networking/templates/networking/index.html
@@ -7,8 +7,8 @@
 {% endblock page_header %}
 
 {% block main %}
-<div class="row-fluid">
-  <div class="span12">
+<div class="row">
+  <div class="col-sm-12">
   {{ tab_group.render }}
   </div>
 </div>

--- a/contrail_openstack_dashboard/openstack_dashboard/dashboards/project/networking/templates/networking/ports/detail.html
+++ b/contrail_openstack_dashboard/openstack_dashboard/dashboards/project/networking/templates/networking/ports/detail.html
@@ -7,8 +7,8 @@
 {% endblock page_header %}
 
 {% block main %}
-<div id="row-fluid">
-  <div class="span12">
+<div id="row">
+  <div class="col-sm-12">
     {{ tab_group.render }}
   </div>
 </div>

--- a/contrail_openstack_dashboard/openstack_dashboard/dashboards/project/networking/templates/networking/subnets/detail.html
+++ b/contrail_openstack_dashboard/openstack_dashboard/dashboards/project/networking/templates/networking/subnets/detail.html
@@ -7,8 +7,8 @@
 {% endblock page_header %}
 
 {% block main %}
-<div id="row-fluid">
-  <div class="span12">
+<div id="row">
+  <div class="col-sm-12">
     {{ tab_group.render }}
   </div>
 </div>


### PR DESCRIPTION
In OpenStack Juno, the overall CSS of the dashboard has changed in some
ways, introducing new CSS elements. This patch adapts the Contrail
plugin for Horizon to reflect the new CSS structure and make the pages
introduced by the plugin look nicely again.

Conflicts:
    openstack_dashboard/dashboards/project/lbaas/templates/lbaas/details_tabs.html
